### PR TITLE
Log and Integer casting to String

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 .project
 .settings/
 target/
+.idea/
 work/
 *.class
 *.jar
 *.hpi
+*.iml
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,10 @@
             <id>vjuranek</id>
             <name>Vojtech Juranek</name>
         </developer>
+        <developer>
+            <id>dlovison</id>
+            <name>Diego Lovison</name>
+        </developer>
     </developers>
 
     <scm>
@@ -60,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
@@ -139,6 +139,8 @@ public class RadarGunBuilder extends Builder {
 
         NodeList nodes = nodeSource.getNodesList(launcher.getChannel());
 
+        console.log(nodes.toString());
+
         //check deprecated options
         console.logAnnot("[RadarGun] WARN: As of RG plugin release 1.3, \"Start script\" config will be replaced by \"Remote login program\" "
                 + "options with limited config. options. Please make sure you don't use anything special in your start scripts (besides launching "

--- a/src/main/java/org/jenkinsci/plugins/radargun/model/impl/MasterNode.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/model/impl/MasterNode.java
@@ -21,7 +21,7 @@ public class MasterNode extends Node {
         super(name, fqdn);
     }
 
-    public MasterNode(String hostname, String fqdn, String jvmOptions, Map<String, String> javaProps, Map<String, String> envVars, List<String> beforeCmds, List<String> afterCmds, boolean gatherLogs) {
+    public MasterNode(String hostname, String fqdn, String jvmOptions, Map<String, Object> javaProps, Map<String, String> envVars, List<String> beforeCmds, List<String> afterCmds, boolean gatherLogs) {
         super(hostname, fqdn, jvmOptions, javaProps, envVars, beforeCmds, afterCmds, gatherLogs);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/radargun/model/impl/Node.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/model/impl/Node.java
@@ -119,4 +119,12 @@ public class Node {
         sb.append('\'');
         return sb.toString();
     }
+
+    @Override
+    public String toString() {
+        return "Node{" +
+              "name='" + name + '\'' +
+              ", fqdn='" + fqdn + '\'' +
+              '}';
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/radargun/model/impl/Node.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/model/impl/Node.java
@@ -8,7 +8,7 @@ public class Node {
     private final String name; // name of the node. If fqdn is not specified, it's assumes that this is the hostname
     private final String fqdn; // fully qualified domain name
     private final String jvmOptions; // additional JVM settings, like -Xmx
-    private final Map<String, String> javaProps; // java properties, typically some RG scenatio variables, "-D" prefix
+    private final Map<String, Object> javaProps; // java properties, typically some RG scenatio variables, "-D" prefix
                                                  // will be automatically added
     private final Map<String, String> envVars;
     private final List<String> beforeCmds;
@@ -37,7 +37,7 @@ public class Node {
         this.gatherLogs = true;
     }
 
-    public Node(String name, String fqdn, String jvmOptions, Map<String, String> javaProps, Map<String, String> envVars, List<String> beforeCmds, List<String> afterCmds, boolean gatherLogs) {
+    public Node(String name, String fqdn, String jvmOptions, Map<String, Object> javaProps, Map<String, String> envVars, List<String> beforeCmds, List<String> afterCmds, boolean gatherLogs) {
         this.name = name;
         this.fqdn = fqdn;
         this.jvmOptions = jvmOptions;
@@ -75,7 +75,7 @@ public class Node {
         return jvmOptions;
     }
 
-    public Map<String, String> getJavaProps() {
+    public Map<String, Object> getJavaProps() {
         return javaProps;
     }
 
@@ -99,7 +99,7 @@ public class Node {
         if (javaProps == null || javaProps.size() == 0) return null;
         
         StringBuilder sb = new StringBuilder();
-        for(Map.Entry<String, String> prop : javaProps.entrySet()) {
+        for(Map.Entry<String, Object> prop : javaProps.entrySet()) {
             sb.append("-D").append(prop.getKey()).append('=').append(prop.getValue()).append(' ');
         }
         return sb.toString();

--- a/src/main/java/org/jenkinsci/plugins/radargun/model/impl/NodeList.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/model/impl/NodeList.java
@@ -50,4 +50,11 @@ public class NodeList {
     public int getSlaveCount() {
         return nodes.size() - 1;
     }
+
+    @Override
+    public String toString() {
+        return "NodeList{" +
+              "nodes=" + nodes +
+              '}';
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/radargun/yaml/YamlNodeConfigParser.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/yaml/YamlNodeConfigParser.java
@@ -98,7 +98,7 @@ public class YamlNodeConfigParser implements NodeConfigParser {
             LOGGER.warning("Setting up JVM options via RG jenkins plugin is deprecated and will be removed. Please use RG 3 or higher and set up JVM options direcly in RG!");
         }
         @SuppressWarnings("unchecked")
-        Map<String, String> javaProps = nodeConfig.containsKey(JAVA_PROPS_KEY) ? (Map<String, String>) nodeConfig
+        Map<String, Object> javaProps = nodeConfig.containsKey(JAVA_PROPS_KEY) ? (Map<String, Object>) nodeConfig
                 .get(JAVA_PROPS_KEY) : null;
         @SuppressWarnings("unchecked")
         Map<String, String> envVars = nodeConfig.containsKey(ENV_VARS_KEY) ? ParseUtils.mapToStringMap(nodeConfig

--- a/src/test/java/org/jenkinsci/plugins/radargun/config/ScriptsourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/radargun/config/ScriptsourceTest.java
@@ -16,19 +16,19 @@ import org.junit.Test;
 public class ScriptsourceTest {
 
     private Map<String, String> env;
-    private Map<String, String> javaProps;
+    private Map<String, Object> javaProps;
     private Node node;
     private NodeScriptConfig nodeCfg;
     private ScriptSource scriptSourceImpl;
 
     @Before
     public void setup() {
-        env = new HashMap<String, String>();
+        env = new HashMap<>();
         env.put("key1", "value1");
         env.put("key2", "");
         env.put("key3", "value3");
 
-        javaProps = new HashMap<String, String>();
+        javaProps = new HashMap<>();
         javaProps.put("-Dmy_prop1", "prop1");
         javaProps.put("-Dmy_prop2", "prop2");
 

--- a/src/test/java/org/jenkinsci/plugins/radargun/model/impl/NodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/radargun/model/impl/NodeTest.java
@@ -12,21 +12,23 @@ public class NodeTest {
 
     @Test
     public void testAllJavaOpts() {
-        Map<String, String> javaProps = new HashMap<>();
+        Map<String, Object> javaProps = new HashMap<>();
         javaProps.put("site.default_site.tcp", "192.168.117.12:7800;192.168.117.13:7800;192.168.117.14:7800;");
         javaProps.put("site.default_site.udp", "192.168.117.12:52000;192.168.117.13:52000;192.168.117.14:52000;");
+        javaProps.put("jgroups.bind_addr", "172.18.1.1");
+        javaProps.put("jgroups.bind_port", 7800);
         Map<String, String> envVars = new HashMap<>();
         envVars.put("infinispan_server1_address", "172.12.0.1");
         Node node = new Node("test_hostname", null, "-server -Xms8g -Xmx8g -XX:+UseLargePages", javaProps, envVars, null, null, true);
         assertNotNull(node.getAllJavaOpts());
         assertEquals(
-                " '-server -Xms8g -Xmx8g -XX:+UseLargePages -Dsite.default_site.udp=192.168.117.12:52000;192.168.117.13:52000;192.168.117.14:52000; -Dsite.default_site.tcp=192.168.117.12:7800;192.168.117.13:7800;192.168.117.14:7800; '",
+                " '-server -Xms8g -Xmx8g -XX:+UseLargePages -Djgroups.bind_addr=172.18.1.1 -Dsite.default_site.udp=192.168.117.12:52000;192.168.117.13:52000;192.168.117.14:52000; -Dsite.default_site.tcp=192.168.117.12:7800;192.168.117.13:7800;192.168.117.14:7800; -Djgroups.bind_port=7800 '",
                 node.getAllJavaOpts());
     }
     
     @Test
     public void testJavaOptsOnly() {
-        Map<String, String> javaProps = new HashMap<>();
+        Map<String, Object> javaProps = new HashMap<>();
         javaProps.put("site.default_site.tcp", "192.168.117.12:7800;192.168.117.13:7800;192.168.117.14:7800;");
         javaProps.put("site.default_site.udp", "192.168.117.12:52000;192.168.117.13:52000;192.168.117.14:52000;");
         Map<String, String> envVars = new HashMap<>();

--- a/src/test/java/org/jenkinsci/plugins/radargun/util/ParseUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/radargun/util/ParseUtilsTest.java
@@ -34,7 +34,7 @@ public class ParseUtilsTest {
         assertNotNull(envVars);
         assertEquals("172.12.0.8", envVars.get("jgroups.udp.mcast_addr"));
         assertEquals("172.12.0.1", envVars.get("infinispan_server1_address"));
-        Map<String, String> javaProps = master.getJavaProps();
+        Map<String, Object> javaProps = master.getJavaProps();
         assertNotNull(javaProps);
         assertEquals("192.168.117.12:7800;192.168.117.13:7800;192.168.117.14:7800;", javaProps.get("site.default_site.tcp"));
         List<String> beforeCmds = master.getBeforeCmds();


### PR DESCRIPTION
For some reason when running on Jenkins we have the failure:

```
[RadarGun] ERROR: something went wrong, caught exception: java.lang.Integer cannot be cast to java.lang.String
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at org.jenkinsci.plugins.radargun.model.impl.Node.getJavaPropsWithPrefix(Node.java:103)
	at org.jenkinsci.plugins.radargun.model.impl.Node.getAllJavaOpts(Node.java:110)
	at org.jenkinsci.plugins.radargun.model.impl.RgSlaveProcessImpl.getSlaveCmdLine(RgSlaveProcessImpl.java:52)
	at org.jenkinsci.plugins.radargun.model.impl.RgSlaveProcessImpl.createRunner(RgSlaveProcessImpl.java:32)
	at org.jenkinsci.plugins.radargun.model.impl.AbstractRgProcess.start(AbstractRgProcess.java:24)
	at org.jenkinsci.plugins.radargun.RadarGunBuilder.perform(RadarGunBuilder.java:158)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
	at hudson.model.Build$BuildExecution.build(Build.java:206)
	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1798)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```