### PR TITLE
[JENKINS-63220] Replace usage of description in favor of help

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/radargun/RadarGunBuilder.java
@@ -270,13 +270,6 @@ public class RadarGunBuilder extends Builder {
             return "Run RadarGun";
         }
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            req.bindJSON(this, formData);
-            save();
-            return super.configure(req, formData);
-        }
-
         public ListBoxModel doFillRadarGunNameItems() {
             ListBoxModel lb = new ListBoxModel();
             for (RadarGunInstallation rgi : installations) {

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/config.jelly
@@ -1,9 +1,8 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-    xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
 
     <j:set var="currInstall" value="${instance.radarGunInstance}" />
-    <f:dropdownList name="radarGunInstance" title="RadarGun instance" description="RadarGun installation to be used">
+    <f:dropdownList name="radarGunInstance" title="RadarGun instance" help="${descriptor.getHelpFile('radarGunInstance')}">
         <j:forEach var="desc" items="${descriptor.rgInstances}" varStatus="loop">
             <f:dropdownListBlock title="${desc.displayName}" value="${loop.index}"
                 selected="${desc==currInstall.descriptor}" staplerClass="${desc.clazz.name}">
@@ -14,7 +13,7 @@
     </f:dropdownList>
 
     <j:set var="currScenario" value="${instance.scenarioSource}" />
-    <f:dropdownList name="scenarioSource" title="RadarGun scenario" description="RadarGun scenarion to be executed">
+    <f:dropdownList name="scenarioSource" title="RadarGun scenario" help="${descriptor.getHelpFile('scenarioSource')}">
         <j:forEach var="desc" items="${descriptor.scenarioSources}" varStatus="loop">
             <f:dropdownListBlock title="${desc.displayName}" value="${loop.index}"
                 selected="${desc==currScenario.descriptor}" staplerClass="${desc.clazz.name}">
@@ -25,7 +24,7 @@
     </f:dropdownList>
 
     <j:set var="currNode" value="${instance.nodeSource}" />
-    <f:dropdownList name="nodeSource" title="Node list" description="List of the nodes where RadarGun will run">
+    <f:dropdownList name="nodeSource" title="Node list" help="${descriptor.getHelpFile('nodeSource')}">
         <j:forEach var="desc" items="${descriptor.nodeSources}" varStatus="loop">
             <f:dropdownListBlock title="${desc.displayName}" value="${loop.index}" selected="${desc==currNode.descriptor}"
                 staplerClass="${desc.clazz.name}">
@@ -40,8 +39,7 @@
     </f:entry>
 
     <j:set var="currScript" value="${instance.scriptSource}" />
-    <f:dropdownList name="scriptSource" title="Start script"
-        description="Script which will be used for staring appropriate processes on nodes">
+    <f:dropdownList name="scriptSource" title="Start script" help="${descriptor.getHelpFile('scriptSource')}">
         <j:forEach var="desc" items="${descriptor.scriptSources}" varStatus="loop">
             <f:dropdownListBlock title="${desc.displayName}" value="${loop.index}" selected="${desc==currScript.descriptor}"
                 staplerClass="${desc.clazz.name}">

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/global.jelly
@@ -1,6 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-    xmlns:f="/lib/form">
-
-
-</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-nodeSource.html
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-nodeSource.html
@@ -1,0 +1,3 @@
+<div>
+  List of the nodes where RadarGun will run
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-radarGunInstance.html
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-radarGunInstance.html
@@ -1,0 +1,3 @@
+<div>
+  RadarGun installation to be used
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-scenarioSource.html
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-scenarioSource.html
@@ -1,0 +1,3 @@
+<div>
+  RadarGun scenario to be executed
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-scriptSource.html
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunBuilder/help-scriptSource.html
@@ -1,0 +1,3 @@
+<div>
+  Script which will be used for starting appropriate processes on nodes
+</div>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/4878 and [JENKINS-63220](https://issues.jenkins-ci.org/browse/JENKINS-63220) for more details.

After the other PR is merged, the descriptions used in dropdownList will no longer work. This PR can be merged whenever you want, even before the other one as it's using the existing help attribute.

<details>

<summary>Screenshot</summary>

### Before
![Screenshot_2020-07-27_142702_001](https://user-images.githubusercontent.com/2662497/88541981-ef8b5d00-d015-11ea-979b-7e8d2440db91.png)


### After
![Screenshot_2020-07-27_142820_001](https://user-images.githubusercontent.com/2662497/88541984-f1edb700-d015-11ea-93b1-4749be5b0697.png)


</details>