### PR TITLE
Use documentation as code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>1.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>RadarGun</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/RadarGun+plugin</url>
+    <url>https://github.com/jenkinsci/radargun-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
README was not referenced from pom, needed for docs as code.

After the next release of the plugin, https://plugins.jenkins.io/radargun/ will include the documentation from https://github.com/jenkinsci/radargun-plugin/blob/master/README.adoc instead of the more brief text that is there currently.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
