### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunNodeAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunNodeAction/index.jelly
@@ -8,7 +8,7 @@
             <h1>RadarGun: output from node ${it.hostname}</h1>
             <l:rightspace>
                 <a href="consoleText">
-                    <img src="${imagesURL}/24x24/document.gif" alt="" />
+                    <l:icon class="icon-document icon-md" />
                     View as plain text
                 </a>
             </l:rightspace>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @vjuranek 
Thanks in advance!