### PR TITLE
Replace EOL spinner.gif

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunNodeAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/radargun/RadarGunNodeAction/index.jelly
@@ -17,7 +17,7 @@
                 <j:when test="${it.inProgress}">
                     <pre id="out"></pre>
                     <div id="spinner">
-                        <img src="${imagesURL}/spinner.gif" />
+                        <l:progressAnimation/>
                     </div>
                     <t:progressiveText href="progressiveLog" idref="out" spinner="spinner" />
                 </j:when>


### PR DESCRIPTION
The change proposed replaces the EOL spinner.gif with the drop-in Jelly tag replacement.